### PR TITLE
Confirm result rather than auto fast forward

### DIFF
--- a/bga_src/backend/dbmodel.sql
+++ b/bga_src/backend/dbmodel.sql
@@ -61,4 +61,12 @@ CREATE TABLE IF NOT EXISTS `reincarnation` (
   `reincarnation_next_player` INT(10) UNSIGNED
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
 
+CREATE TABLE IF NOT EXISTS `score` (
+  `score_round` INT(10) UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  `score_center_list` VARCHAR(18),
+  `score_sun_list` VARCHAR(18),
+  `score_night_list` VARCHAR(18),
+  `score_winner` VARCHAR(30)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+
 -- ALTER TABLE `player` ADD `player_side` VARCHAR(16);

--- a/bga_src/backend/states.inc.php
+++ b/bga_src/backend/states.inc.php
@@ -138,9 +138,13 @@ $machinestates = [
 
   51 => [
     "name" => "endRound",
-    "type" => "game",
+    "descriptionmyturn" => clienttranslate(
+      'Waiting for all the players to confirm the result'
+    ),
+    "type" => "multipleactiveplayer",
     "action" => "stEndRound",
     "updateGameProgression" => true,
+    "possibleactions" => ["endRoundConfirm"],
     "transitions" => ["roundSetup" => 2, "endGame" => 99],
   ],
 

--- a/bga_src/backend/states.inc.php
+++ b/bga_src/backend/states.inc.php
@@ -72,10 +72,10 @@ $machinestates = [
   11 => [
     "name" => "mulliganTurn",
     "description" => clienttranslate(
-      '${actplayer} may discard to draw a new card'
+      '${actplayer} may discard to draw a new card.'
     ),
     "descriptionmyturn" => clienttranslate(
-      '${you} may discard a card to draw a new card'
+      '${you} may discard a card to draw a new card.'
     ),
     "type" => "activeplayer",
     "possibleactions" => ["mulligan"],
@@ -96,8 +96,8 @@ $machinestates = [
 
   21 => [
     "name" => "playerTurn",
-    "description" => clienttranslate('${actplayer} must play a card'),
-    "descriptionmyturn" => clienttranslate('${you} must play a card'),
+    "description" => clienttranslate('${actplayer} must play a card.'),
+    "descriptionmyturn" => clienttranslate('${you} must play a card.'),
     "type" => "activeplayer",
     "possibleactions" => ["playCard"],
     "transitions" => [
@@ -118,10 +118,10 @@ $machinestates = [
   31 => [
     "name" => "reincarnationTurn",
     "description" => clienttranslate(
-      '${actplayer} must play the reincarnated card'
+      '${actplayer} must play the reincarnated card.'
     ),
     "descriptionmyturn" => clienttranslate(
-      '${you} must play the reincarnated card'
+      '${you} must play the reincarnated card.'
     ),
     "type" => "activeplayer",
     "possibleactions" => ["playCard"],
@@ -138,9 +138,8 @@ $machinestates = [
 
   51 => [
     "name" => "endRound",
-    "descriptionmyturn" => clienttranslate(
-      'Waiting for all the players to confirm the result'
-    ),
+    "description" => clienttranslate('${actplayer} is confirming the result.'),
+    "descriptionmyturn" => clienttranslate('Press "Confirm" to continue.'),
     "type" => "multipleactiveplayer",
     "action" => "stEndRound",
     "updateGameProgression" => true,

--- a/bga_src/backend/vughex.action.php
+++ b/bga_src/backend/vughex.action.php
@@ -43,9 +43,7 @@ class action_vughex extends APP_GameAction
     self::setAjaxMode();
     $cardID = self::getArg("card", AT_alphanum, false);
 
-    $this->game->mulligan(
-      $cardID,
-    );
+    $this->game->mulligan($cardID);
     self::ajaxResponse();
   }
 
@@ -65,6 +63,13 @@ class action_vughex extends APP_GameAction
       $targetGridSide,
       $targetCol
     );
+    self::ajaxResponse();
+  }
+
+  public function endRoundConfirm()
+  {
+    self::setAjaxMode();
+    $this->game->endRoundConfirm();
     self::ajaxResponse();
   }
 }

--- a/bga_src/client/type/gamedata.d.ts
+++ b/bga_src/client/type/gamedata.d.ts
@@ -47,6 +47,11 @@ interface Gamedata {
   };
   reincarnated_card_id?: string | null;
   reincarnated_col?: string | null;
+  score?: {
+    [playerId: number | "center"]: number[];
+  };
+  winner?: string[];
+
 }
 
 export { CardMeta, Card, Score, Gamedata };

--- a/bga_src/client/type/stock.d.ts
+++ b/bga_src/client/type/stock.d.ts
@@ -1,5 +1,5 @@
 import { Game } from "./framework.d";
-import { Card } from "./vughex.d";
+import { Card } from "./gamedata.d";
 
 interface StockItems {
   id: string;

--- a/bga_src/client/vughex.ts
+++ b/bga_src/client/vughex.ts
@@ -204,7 +204,7 @@ define([
           break;
 
         case "endRound":
-          vue.bgaStates.push("endRound");
+          vue.bgaStates.push("endRound:init");
           break;
 
         case "dummmy":

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,6 +55,13 @@
         auraType="cancel"
         @btnClick="submitState()"
       ></CtrlButton>
+      <CtrlButton
+        type="confirm"
+        :active="ctrlButtonData.confirm.active"
+        :display="ctrlButtonData.confirm.display"
+        auraType="submit"
+        @btnClick="submitState()"
+      ></CtrlButton>
     </div>
 
     <div id="player_hand" class="whiteblock">
@@ -103,6 +110,7 @@ import GameCard from "./components/GameCard.vue";
 import Hand from "./components/Hand.vue";
 import Grid from "./components/Grid.vue";
 import CtrlButton from "./components/CtrlButton.vue";
+import { objToArray } from "./util/util";
 
 @Options({
   components: {
@@ -179,12 +187,17 @@ export default class App extends Vue {
       active: true,
       display: false,
     },
+    confirm: {
+      active: true,
+      display: false,
+    },
   };
 
   public scoreData: ScoreData = {
     centerScore: [],
     oppoScore: [],
     myScore: [],
+    result: [],
   };
 
   public reincarnationData: ReincarnationData = {
@@ -305,6 +318,34 @@ export default class App extends Vue {
       };
     });
 
+    // restore score
+    if (this.gamedata.score) {
+      const score = this.gamedata.score;
+      for (const pID in score) {
+        if (pID === "center") {
+          this.scoreData.centerScore = objToArray(score[pID]);
+        } else if (pID === String(this.playerID)) {
+          this.scoreData.myScore = objToArray(score[pID]);
+        } else {
+          this.scoreData.oppoScore = objToArray(score[pID]);
+        }
+      }
+    }
+    if (this.gamedata.winner) {
+      this.gamedata.winner.forEach((winner, idx: number) => {
+        if (!this.scoreData.result) {
+          this.scoreData.result = [];
+        }
+        if (Number(winner) === 0) {
+          this.scoreData.result[idx] = "tie";
+        } else if (Number(winner) === Number(this.playerID)) {
+          this.scoreData.result[idx] = "win";
+        } else {
+          this.scoreData.result[idx] = "lose";
+        }
+      });
+    }
+
     this.reincarnationData.reincarnatedCardID =
       this.gamedata.reincarnated_card_id || null;
 
@@ -393,13 +434,14 @@ export default class App extends Vue {
               // without delay
               resolve();
               break;
-            case "endRound":
-              this.sub?.handle(notif);
-              // FIXME: this should be configurable
-              setTimeout(() => {
-                resolve();
-              }, 10000);
-              break;
+            // case "endRound": {
+            //   this.sub?.handle(notif);
+            //   // FIXME: this should be configurable
+            //   setTimeout(() => {
+            //     resolve();
+            //   }, 10000);
+            //   break;
+            // }
             default:
               this.sub?.handle(notif);
               setTimeout(() => {
@@ -422,13 +464,14 @@ export default class App extends Vue {
       this.bgaStateQueue = this.bgaStateQueue.then(() => {
         return new Promise<void>((resolve) => {
           switch (state) {
-            case "endRound":
-              this.state?.setState(state);
-              setTimeout(() => {
-                // secure the least time gap
-                resolve();
-              }, 10000);
-              break;
+            // case "endRound": {
+            //   this.state?.setState(state);
+            //   setTimeout(() => {
+            //     // secure the least time gap
+            //     resolve();
+            //   }, 10000);
+            //   break;
+            // }
             default:
               this.state?.setState(state);
               setTimeout(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -434,14 +434,6 @@ export default class App extends Vue {
               // without delay
               resolve();
               break;
-            // case "endRound": {
-            //   this.sub?.handle(notif);
-            //   // FIXME: this should be configurable
-            //   setTimeout(() => {
-            //     resolve();
-            //   }, 10000);
-            //   break;
-            // }
             default:
               this.sub?.handle(notif);
               setTimeout(() => {
@@ -464,14 +456,6 @@ export default class App extends Vue {
       this.bgaStateQueue = this.bgaStateQueue.then(() => {
         return new Promise<void>((resolve) => {
           switch (state) {
-            // case "endRound": {
-            //   this.state?.setState(state);
-            //   setTimeout(() => {
-            //     // secure the least time gap
-            //     resolve();
-            //   }, 10000);
-            //   break;
-            // }
             default:
               this.state?.setState(state);
               setTimeout(() => {

--- a/src/def/ctrlButton.ts
+++ b/src/def/ctrlButton.ts
@@ -29,6 +29,13 @@ const ctrlButtonDefs: { [cardType in ButtonType]: CtrlButtonDef } = {
     background: "#3d50ff",
     border: "2px solid #adc1ff",
   },
+  confirm: {
+    label: "Confirm",
+    size: { width: "138px", height: "30px", radius: "15px" },
+    textColor: "white",
+    background: "#ff621f",
+    border: "2px solid #ffb571",
+  },
 };
 
 export { ctrlButtonDefs };

--- a/src/logic/sub.ts
+++ b/src/logic/sub.ts
@@ -13,7 +13,7 @@ import { objToArray } from "../util/util";
 
 import { GridData } from "../type/Grid.d";
 import { HandData } from "../type/Hand.d";
-import { ScoreData } from "../type/Score.d";
+import { ScoreData, ScoreResult } from "../type/Score.d";
 import { ReincarnationData } from "../type/Reincarnation.d";
 
 //
@@ -249,21 +249,7 @@ export class Sub {
         if (!this.gridData || !wPlayerID || !lane) {
           break;
         }
-        let idx = 0;
-        let delay = 0;
-        let result = "tie";
-        if (lane === "left") {
-          idx = 0;
-          delay = 1000;
-        }
-        if (lane === "center") {
-          idx = 1;
-          delay = 2000;
-        }
-        if (lane === "right") {
-          idx = 2;
-          delay = 3000;
-        }
+        let result: ScoreResult = "tie";
         if (Number(wPlayerID) === Number(this.playerID)) {
           result = "win";
         }
@@ -273,35 +259,19 @@ export class Sub {
         ) {
           result = "lose";
         }
-        setTimeout(() => {
-          if (!this.gridData.overlay) {
-            this.gridData.overlay = [];
-          }
-          if (result === "win") {
-            this.gridData.overlay[idx] = {
-              type: "text",
-              data: "Win!",
-              pos: `col.${idx}.bottom`,
-              cssClass: "largeCenter success",
-            };
-          }
-          if (result === "lose") {
-            this.gridData.overlay[idx] = {
-              type: "text",
-              data: "Lose..",
-              pos: `col.${idx}.bottom`,
-              cssClass: "largeCenter danger",
-            };
-          }
-          if (result === "tie") {
-            this.gridData.overlay[idx] = {
-              type: "text",
-              data: "Tie",
-              pos: `col.${idx}.bottom`,
-              cssClass: "largeCenter",
-            };
-          }
-        }, delay);
+
+        if (!this.scoreData.result) {
+          this.scoreData.result = [];
+        }
+        if (lane === "left") {
+          this.scoreData.result[0] = result;
+        }
+        if (lane === "center") {
+          this.scoreData.result[1] = result;
+        }
+        if (lane === "right") {
+          this.scoreData.result[2] = result;
+        }
         break;
       }
 

--- a/src/type/CtrlButtonDef.d.ts
+++ b/src/type/CtrlButtonDef.d.ts
@@ -1,4 +1,4 @@
-type ButtonType = "cancel" | "submit" | "mulligan" | "noMulligan";
+type ButtonType = "cancel" | "submit" | "mulligan" | "noMulligan" | "confirm";
 
 interface ButtonSizeDef {
   width: string;

--- a/src/type/Score.d.ts
+++ b/src/type/Score.d.ts
@@ -1,7 +1,10 @@
+type ScoreResult = "win" | "lose" | "tie";
+
 interface ScoreData {
   centerScore: string[];
   oppoScore: string[];
   myScore: string[];
+  result?: ScoreResult[];
 }
 
-export { ScoreData };
+export { ScoreData, ScoreResult };


### PR DESCRIPTION
Do not fast forward the round result.
Instead, show confirm button at round result in `multipleactiveplayer` mode.
This indirectly means we have to store the round result in DB.
(otherwise we cannot restore the state)
