### PR TITLE
fix maze col select on player side #87656

### DIFF
--- a/src/logic/state.ts
+++ b/src/logic/state.ts
@@ -621,7 +621,7 @@ class State {
       if (ix === x) {
         continue;
       }
-      let ymax = 5;
+      let ymax = 4;
       if (y < 2) {
         ymax = 0;
       }


### PR DESCRIPTION
Fix for https://boardgamearena.com/bug?id=87656

ymax was mistakenly set to 5 instead of 4.
(index starts from 0)

Ideally we shouldn't let player to choose a target card itself though.